### PR TITLE
Replace internal anchors with React Router links

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.0.0",
       "dependencies": {
         "react": "^19.1.1",
-        "react-dom": "^19.1.1"
+        "react-dom": "^19.1.1",
+        "react-router-dom": "^7.9.1"
       },
       "devDependencies": {
         "@eslint/js": "^9.33.0",
@@ -1870,6 +1871,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cookie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
+      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -3340,6 +3350,44 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-router": {
+      "version": "7.9.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.9.1.tgz",
+      "integrity": "sha512-pfAByjcTpX55mqSDGwGnY9vDCpxqBLASg0BMNAuMmpSGESo/TaOUG6BllhAtAkCGx8Rnohik/XtaqiYUJtgW2g==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.9.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.9.1.tgz",
+      "integrity": "sha512-U9WBQssBE9B1vmRjo9qTM7YRzfZ3lUxESIZnsf4VjR/lXYz9MHjvOxHzr/aUm4efpktbVOrF09rL/y4VHa8RMw==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.9.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
     "node_modules/read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -3498,6 +3546,12 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
+      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
+      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   },
   "dependencies": {
     "react": "^19.1.1",
-    "react-dom": "^19.1.1"
+    "react-dom": "^19.1.1",
+    "react-router-dom": "^7.9.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.33.0",

--- a/src/components/DesktopView.jsx
+++ b/src/components/DesktopView.jsx
@@ -1,3 +1,5 @@
+import { Link } from 'react-router-dom'
+
 const navigation = [
   { name: 'Solutions', href: '#solutions' },
   { name: 'Insights', href: '#insights' },
@@ -53,24 +55,24 @@ const DesktopView = () => {
           </div>
           <nav className="flex items-center gap-10 text-sm font-medium text-slate-600">
             {navigation.map((item) => (
-              <a key={item.name} href={item.href} className="transition-colors hover:text-brand-600">
+              <Link key={item.name} to={item.href} className="transition-colors hover:text-brand-600">
                 {item.name}
-              </a>
+              </Link>
             ))}
           </nav>
           <div className="flex items-center gap-4 text-sm">
-            <a
-              href="#contact"
+            <Link
+              to="#contact"
               className="rounded-full border border-slate-200 px-5 py-2 font-medium text-slate-600 transition hover:border-brand-400 hover:text-brand-600"
             >
               Log in
-            </a>
-            <a
-              href="#contact"
+            </Link>
+            <Link
+              to="#contact"
               className="rounded-full bg-brand-500 px-6 py-2 text-sm font-semibold text-white shadow-lg shadow-brand-500/25 transition hover:bg-brand-600"
             >
               Start investing
-            </a>
+            </Link>
           </div>
         </header>
 
@@ -88,16 +90,16 @@ const DesktopView = () => {
                 advisors who translate market complexity into confident decisions.
               </p>
               <div className="flex items-center gap-6 pt-2 text-sm font-medium">
-                <a
-                  href="#contact"
+                <Link
+                  to="#contact"
                   className="rounded-full bg-midnight px-7 py-3 text-white shadow-lg shadow-midnight/30 transition hover:bg-slate-900"
                 >
                   Book a consultation
-                </a>
-                <a href="#insights" className="inline-flex items-center gap-2 text-slate-600 transition hover:text-brand-600">
+                </Link>
+                <Link to="#insights" className="inline-flex items-center gap-2 text-slate-600 transition hover:text-brand-600">
                   Explore insights
                   <span aria-hidden="true">→</span>
-                </a>
+                </Link>
               </div>
               <dl className="grid grid-cols-3 gap-6 pt-6 text-left">
                 {stats.map((item) => (
@@ -155,12 +157,12 @@ const DesktopView = () => {
                   <article key={item.title} className="rounded-2xl border border-slate-100 bg-white/80 p-6 shadow-sm">
                     <h3 className="text-2xl font-semibold text-midnight">{item.title}</h3>
                     <p className="mt-3 text-base text-slate-600">{item.description}</p>
-                    <a
-                      href="#contact"
+                    <Link
+                      to="#contact"
                       className="mt-5 inline-flex items-center gap-2 text-sm font-semibold text-brand-600 transition hover:text-brand-700"
                     >
                       Request full report <span aria-hidden="true">→</span>
-                    </a>
+                    </Link>
                   </article>
                 ))}
               </div>
@@ -199,9 +201,9 @@ const DesktopView = () => {
         <footer className="mt-auto flex items-center justify-between border-t border-slate-100 pt-8 text-sm text-slate-500">
           <p>© {new Date().getFullYear()} Grow Invest. All rights reserved.</p>
           <div className="flex items-center gap-6">
-            <a href="#top" className="transition hover:text-brand-600">
+            <Link to="#top" className="transition hover:text-brand-600">
               Back to top
-            </a>
+            </Link>
             <a href="mailto:hello@growinvest.com" className="transition hover:text-brand-600">
               hello@growinvest.com
             </a>

--- a/src/components/MobileView.jsx
+++ b/src/components/MobileView.jsx
@@ -1,3 +1,5 @@
+import { Link } from 'react-router-dom'
+
 const services = [
   {
     title: 'Smart automated portfolios',
@@ -29,12 +31,12 @@ const MobileView = () => {
             <span className="flex h-9 w-9 items-center justify-center rounded-full bg-brand-500/10 text-sm text-brand-600">GI</span>
             Grow Invest
           </span>
-          <a
-            href="#mobile-contact"
+          <Link
+            to="#mobile-contact"
             className="rounded-full border border-slate-200 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-slate-600"
           >
             Get started
-          </a>
+          </Link>
         </header>
 
         <main className="mt-10 space-y-10">

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,10 +1,14 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
-import './index.css'
+import { BrowserRouter } from 'react-router-dom'
+
 import App from './App.jsx'
+import './index.css'
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
-    <App />
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
   </StrictMode>,
 )


### PR DESCRIPTION
## Summary
- add react-router-dom and wrap the root render in a BrowserRouter
- replace desktop and mobile view anchor tags that pointed to in-app sections with Link components so navigation stays client-side

## Testing
- npm run lint
- npm run dev

------
https://chatgpt.com/codex/tasks/task_e_68ca824178a883278781dfffaad86de0